### PR TITLE
Fix for AttributeError in non-blocking example

### DIFF
--- a/examples/nonblocking_execute.py
+++ b/examples/nonblocking_execute.py
@@ -61,10 +61,8 @@ def main():
     s.agent_auth(args.user)
     # Now we can set non-blocking mode
     s.set_blocking(False)
-    chan = None
-    while not chan or chan == LIBSSH2_ERROR_EAGAIN:
-        chan = s.open_session()
-    while chan is None:
+    chan = s.open_session()
+    while chan == LIBSSH2_ERROR_EAGAIN:
         print("Would block on session open, waiting for socket to be ready")
         wait_socket(sock, s)
         chan = s.open_session()

--- a/examples/nonblocking_execute.py
+++ b/examples/nonblocking_execute.py
@@ -61,7 +61,9 @@ def main():
     s.agent_auth(args.user)
     # Now we can set non-blocking mode
     s.set_blocking(False)
-    chan = s.open_session()
+    chan = None
+    while not chan or chan == LIBSSH2_ERROR_EAGAIN:
+        chan = s.open_session()
     while chan is None:
         print("Would block on session open, waiting for socket to be ready")
         wait_socket(sock, s)


### PR DESCRIPTION
Since s.open_session() takes some time, it might happen that chan has the value of LIBSSH2_ERROR_EAGAIN. This is not handled in the code. I've added an other loop that checks for None, which is now the initial value of chan, and LIBSSH2_ERROR_EAGAIN and tries to open the session again in this cases.