### PR TITLE
Greatly speed up sftp_write example for non-trivial files

### DIFF
--- a/examples/sftp_write.py
+++ b/examples/sftp_write.py
@@ -8,8 +8,8 @@ import argparse
 import socket
 import os
 import pwd
-import sys
 from datetime import datetime
+from pathlib import Path
 
 from ssh2.session import Session
 from ssh2.sftp import LIBSSH2_FXF_CREAT, LIBSSH2_FXF_WRITE, \
@@ -44,13 +44,12 @@ def main():
            LIBSSH2_SFTP_S_IRGRP | \
            LIBSSH2_SFTP_S_IROTH
     f_flags = LIBSSH2_FXF_CREAT | LIBSSH2_FXF_WRITE
+    data = Path(args.source).read_bytes()
     print("Starting copy of local file %s to remote %s:%s" % (
         args.source, args.host, args.destination))
     now = datetime.now()
-    with open(args.source, 'rb') as local_fh, \
-            sftp.open(args.destination, f_flags, mode) as remote_fh:
-        for data in local_fh:
-            remote_fh.write(data)
+    with sftp.open(args.destination, f_flags, mode) as remote_fh:
+        remote_fh.write(data)
     print("Finished writing remote file in %s" % (datetime.now() - now,))
 
 


### PR DESCRIPTION
This change loads the entire file into memory and sends that to the sftp
file handler's write. The effect of this is a single call to write
instead of many.
This greatly speeds up the overall sftp write at the expense of loading
the entire file into memory.

In the screenshot below we have two test runs on a 3.8MB file from before the change and two test runs after the change.

![Screenshot from 2021-11-05 09-46-24](https://user-images.githubusercontent.com/6618303/140521697-1651e421-c832-48eb-a23d-3b0a064c58ae.png)
