### PR TITLE
Let user handle keyboard-interactive events

### DIFF
--- a/examples/keyboard_interactive_auth.py
+++ b/examples/keyboard_interactive_auth.py
@@ -1,0 +1,61 @@
+#!/usr/bin/python
+
+"""Example script for authentication with password"""
+
+from __future__ import print_function
+
+import argparse
+import socket
+import os
+import pwd
+import functools
+
+
+from ssh2.session import Session
+
+
+USERNAME = pwd.getpwuid(os.geteuid()).pw_name
+
+parser = argparse.ArgumentParser()
+
+parser.add_argument('password', help="User password")
+parser.add_argument('oauth', help="OAUTH key to use for authentication")
+parser.add_argument('cmd', help="Command to run")
+parser.add_argument('--host', dest='host',
+                    default='localhost',
+                    help='Host to connect to')
+parser.add_argument('--port', dest='port', default=22, help="Port to connect on", type=int)
+parser.add_argument('-u', dest='user', default=USERNAME, help="User name to authenticate as")
+
+
+def oauth_handler(name, instruction, prompts, password, oauth):
+    responses = []
+
+    for prompt in prompts:
+        if "Password:" in prompt:
+            responses.append(password)
+        if "One-time password (OATH) for" in prompt:
+            responses.append(oauth)
+    
+    return responses
+
+def main():
+    args = parser.parse_args()
+
+    callback = functools.partial(oauth_handler,password=args.password,oauth=args.oauth)
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.connect((args.host, args.port))
+    s = Session()
+    s.handshake(sock)
+    s.userauth_keyboardinteractive_callback(args.user, callback)
+    chan = s.open_session()
+    chan.execute(args.cmd)
+    size, data = chan.read()
+    while size > 0:
+        print(data)
+        size, data = chan.read()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Keyboard-interactive events can have multiple steps. Tweak the existing `kbd_callback` to massage prompts into a format that an end user can handle from python.

New public method `userauth_keyboardinteractive_callback` added to the session class to maintain backwards compatibility. See new example script for usage.

I didn't add any new test case since I'm not really sure how it would fit into the existing set-up. To test locally I set spun up a ssh server inside a docker container[^1] and pointed the example script at it. Below is an example command I used:
```bash
OTP=$(oathtool --totp -d 6 12345678909876543210)
python ./examples/keyboard_interactive_auth.py --host 127.0.0.1 --port 2022 -u sshuser $OTP 552099 hostname
```

[^1]:
<details><summary>Example Dockerfile</summary>
<p>

## SSH server with MFA

```
FROM debian:latest

RUN apt-get update && apt-get install -y \
  openssh-server \
  libpam-oath \
  oathtool \
  && rm -rf /var/lib/apt/lists/*

RUN groupadd sshgroup
RUN useradd -ms /bin/bash -g sshgroup -p '$1$sshuser$TCmWDAEGpJ.Z.Sj/NN02I.' sshuser

RUN echo 'HOTP/T30/6 sshuser - 12345678909876543210' > /etc/users.oath 
RUN chmod 600 /etc/users.oath
RUN echo 'auth	  required pam_oath.so usersfile=/etc/users.oath window=30 digits=6' >> /etc/pam.d/sshd
run cat /etc/pam.d/sshd


RUN echo 'ChallengeResponseAuthentication yes \nKbdInteractiveAuthentication yes\n' >> /etc/ssh/sshd_config.d/otp.conf
RUN service ssh start
EXPOSE 22
CMD ["/usr/sbin/sshd","-D"]
```

</p>
</details>
